### PR TITLE
Error:  undefined method `match?' for ".md":String

### DIFF
--- a/_plugins/github-path.rb
+++ b/_plugins/github-path.rb
@@ -8,7 +8,7 @@
 #
 Jekyll::Hooks.register :pages, :post_init do |page|
   # Process only files with 'md' and 'html' extensions
-  next unless File.extname(page.path).match?(/md|html/)
+  next unless File.extname(page.path).match(/md|html/)
   # Do nothing for redirects
   next if page.name == 'redirect.html'
 


### PR DESCRIPTION
## Purpose of this pull request
Trying to generate a preview with the following command:
`master$ bundle exec jekyll serve --incremental`
Result in the following error:
```
Configuration file: /Volumes/Projects/devdocs/_config.yml
Invalid theme folder: _sass
            Source: /Volumes/Projects/devdocs
       Destination: /Volumes/Projects/devdocs/_site
 Incremental build: enabled
      Generating...
jekyll 3.8.5 | Error:  undefined method `match?' for ".md":String
Did you mean?  match
```